### PR TITLE
Remove Bearer header from response

### DIFF
--- a/ginoauth2.go
+++ b/ginoauth2.go
@@ -307,9 +307,6 @@ func AuthChain(endpoints oauth2.Endpoint, accessCheckFunctions ...AccessCheckFun
 			return
 		}
 
-		// access allowed
-		ctx.Writer.Header().Set("Bearer", tokenContainer.Token.AccessToken)
-
 		glog.V(2).Infof("[Gin-OAuth] %12v %s access allowed", time.Since(t), ctx.Request.URL.Path)
 	}
 }


### PR DESCRIPTION
As far as I know setting a `Bearer` header has no meaning and thus shouldn't be set in the response. It also seems wrong to return the token to the user in the response, so just not setting the header seems like the right thing to do.