### PR TITLE
adding identification for services/users

### DIFF
--- a/zalando/zalando.go
+++ b/zalando/zalando.go
@@ -137,6 +137,10 @@ func ScopeCheck(name string, scopes ...string) func(tc *ginoauth2.TokenContainer
 				ctx.Set(s, cur) // set value from token of configured scope to the context, which you can use in your application.
 			}
 		}
+		//Getting the uid for identification of the service calling
+		if cur, ok := tc.Scopes["uid"]; ok {
+			ctx.Set("uid", cur)
+		}
 		return len(scopesFromToken) > 0
 	}
 }
@@ -157,6 +161,10 @@ func ScopeAndCheck(name string, scopes ...string) func(tc *ginoauth2.TokenContai
 			} else {
 				return false
 			}
+		}
+		//Getting the uid for identification of the service calling
+		if cur, ok := tc.Scopes["uid"]; ok {
+			ctx.Set("uid", cur)
 		}
 		return true
 	}

--- a/zalando/zalando_test.go
+++ b/zalando/zalando_test.go
@@ -95,6 +95,10 @@ func TestScopeCheck(t *testing.T) {
 	scopeVal, scopeOk := ctx.Get("my-scope-1")
 	assert.True(t, scopeOk)
 	assert.Equal(t, true, scopeVal)
+
+	uid, uidOk := ctx.Get("uid")
+	assert.True(t, uidOk)
+	assert.Equal(t, "stups_marilyn-updater", uid)
 }
 
 func TestScopeAndCheck(t *testing.T) {


### PR DESCRIPTION
In case `uid` is not a requested scope, the functions `ScopeCheck` and `ScopeAndCheck` do not put the uid in the context.
Even if it is not a requested scope, it might be useful to identify the caller to extract the uid, which can be used in the application for example for logging.