### PR TITLE
Fix session handling for Google login

### DIFF
--- a/example/google/google.go
+++ b/example/google/google.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/zalando/gin-oauth2/google"
+	goauth "google.golang.org/api/oauth2/v2"
 )
 
 var redirectURL, credFile string
@@ -54,5 +55,15 @@ func main() {
 }
 
 func UserInfoHandler(ctx *gin.Context) {
-	ctx.JSON(http.StatusOK, gin.H{"Hello": "from private", "user": ctx.MustGet("user").(google.User)})
+	var (
+		res goauth.Userinfo
+		ok  bool
+	)
+
+	val := ctx.MustGet("user")
+	if res, ok = val.(goauth.Userinfo); !ok {
+		res = goauth.Userinfo{Name: "no user"}
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"Hello": "from private", "user": res.Email})
 }


### PR DESCRIPTION
This PR fixes the session handling for the Google Login in a way
that it's not necessary to do the auth code flow every time. If a
session with a valid Userinfo object is found, it will skip the oauth
authentication flow.

The implementation is similar to the modifications made for Github:
https://github.com/zalando/gin-oauth2/pull/59

Also fixes #66 