### PR TITLE
76 google oauth config mutator

### DIFF
--- a/google/google.go
+++ b/google/google.go
@@ -74,6 +74,19 @@ func Setup(redirectURL, credFile string, scopes []string, secret []byte) {
 	}
 }
 
+// Setup the authorization path without a config file
+func SetupFromString(redirectURL, clientID string, clientSecret string, scopes []string, secret []byte) {
+	store = sessions.NewCookieStore(secret)
+
+	conf = &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+		Scopes:       scopes,
+		Endpoint:     google.Endpoint,
+	}
+}
+
 func Session(name string) gin.HandlerFunc {
 	return sessions.Sessions(name, store)
 }

--- a/google/google.go
+++ b/google/google.go
@@ -78,9 +78,8 @@ func Setup(redirectURL, credFile string, scopes []string, secret []byte) {
 }
 
 // Setup the authorization path without a config file
-func SetupFromString(redirectURL, cLoginURL string, clientID string, clientSecret string, scopes []string, secret []byte) {
+func SetupFromString(redirectURL, clientID string, clientSecret string, scopes []string, secret []byte) {
 	store = cookie.NewStore(secret)
-	loginURL = cLoginURL
 
 	conf = &oauth2.Config{
 		ClientID:     clientID,

--- a/google/google.go
+++ b/google/google.go
@@ -10,9 +10,10 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
@@ -116,8 +117,14 @@ func GetLoginURL(state string) string {
 	return conf.AuthCodeURL(state)
 }
 
-func WithLoginURL(url string) {
-	loginURL = url
+func WithLoginURL(s string) error {
+	s = strings.TrimSpace(s)
+	url, err := url.ParseRequestURI(s)
+	if err != nil {
+		return err
+	}
+	loginURL = url.String()
+	return nil
 }
 
 // Auth is the google authorization middleware. You can use them to protect a routergroup.

--- a/google/google.go
+++ b/google/google.go
@@ -116,6 +116,10 @@ func GetLoginURL(state string) string {
 	return conf.AuthCodeURL(state)
 }
 
+func WithLoginURL(url string) {
+	loginURL = url
+}
+
 // Auth is the google authorization middleware. You can use them to protect a routergroup.
 // Example:
 //

--- a/google/google.go
+++ b/google/google.go
@@ -77,7 +77,7 @@ func Setup(redirectURL, credFile string, scopes []string, secret []byte) {
 	}
 }
 
-// Setup the authorization path without a config file
+// SetupFromString accepts string values for ouath2 Configs
 func SetupFromString(redirectURL, clientID string, clientSecret string, scopes []string, secret []byte) {
 	store = cookie.NewStore(secret)
 

--- a/google/google_test.go
+++ b/google/google_test.go
@@ -1,0 +1,19 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetupFromString(t *testing.T) {
+	t.Run("should assign store and config accordingly", func(t *testing.T) {
+		store = nil
+		conf = nil
+		SetupFromString("http://fake.fake", "clientid", "clientsecret", []string{}, []byte("secret"))
+		assert.NotNil(t, conf)
+		assert.NotNil(t, store)
+		assert.Equal(t, conf.ClientID, "clientid")
+		assert.Equal(t, conf.ClientSecret, "clientsecret")
+	})
+}

--- a/google/google_test.go
+++ b/google/google_test.go
@@ -17,3 +17,13 @@ func TestSetupFromString(t *testing.T) {
 		assert.Equal(t, conf.ClientSecret, "clientsecret")
 	})
 }
+
+func TestWithLoginURL(t *testing.T) {
+	t.Run("should assign the login url", func(t *testing.T) {
+		loginURL = ""
+		url := "http://fake.fake"
+		WithLoginURL(url)
+		assert.NotEmpty(t, url)
+		assert.Equal(t, url, loginURL)
+	})
+}

--- a/google/google_test.go
+++ b/google/google_test.go
@@ -39,7 +39,7 @@ func TestWithLoginURL(t *testing.T) {
 			isErrNil:       true,
 		},
 		{
-			description:    "should not assign an invalid url without error",
+			description:    "should not assign an invalid url, and should return an error",
 			urlParm:        "not a parseable url",
 			expectUrlLogin: "",
 			isErrNil:       false,

--- a/google/google_test.go
+++ b/google/google_test.go
@@ -19,11 +19,38 @@ func TestSetupFromString(t *testing.T) {
 }
 
 func TestWithLoginURL(t *testing.T) {
-	t.Run("should assign the login url", func(t *testing.T) {
-		loginURL = ""
-		url := "http://fake.fake"
-		WithLoginURL(url)
-		assert.NotEmpty(t, url)
-		assert.Equal(t, url, loginURL)
-	})
+
+	var testCases = []struct {
+		description    string
+		urlParm        string
+		expectUrlLogin string
+		isErrNil       bool
+	}{
+		{
+			description:    "should assign a valid url without error",
+			urlParm:        "http://fake.fake",
+			expectUrlLogin: "http://fake.fake",
+			isErrNil:       true,
+		},
+		{
+			description:    "should assign a sanitizable url without error",
+			urlParm:        " http://fake.fake   ",
+			expectUrlLogin: "http://fake.fake",
+			isErrNil:       true,
+		},
+		{
+			description:    "should not assign an invalid url without error",
+			urlParm:        "not a parseable url",
+			expectUrlLogin: "",
+			isErrNil:       false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			loginURL = ""
+			err := WithLoginURL(testCase.urlParm)
+			assert.Equal(t, testCase.expectUrlLogin, loginURL)
+			assert.Equal(t, testCase.isErrNil, err == nil)
+		})
+	}
 }

--- a/google/google_test.go
+++ b/google/google_test.go
@@ -23,25 +23,25 @@ func TestWithLoginURL(t *testing.T) {
 	var testCases = []struct {
 		description    string
 		urlParm        string
-		expectUrlLogin string
+		expectURLLogin string
 		isErrNil       bool
 	}{
 		{
 			description:    "should assign a valid url without error",
 			urlParm:        "http://fake.fake",
-			expectUrlLogin: "http://fake.fake",
+			expectURLLogin: "http://fake.fake",
 			isErrNil:       true,
 		},
 		{
 			description:    "should assign a sanitizable url without error",
 			urlParm:        " http://fake.fake   ",
-			expectUrlLogin: "http://fake.fake",
+			expectURLLogin: "http://fake.fake",
 			isErrNil:       true,
 		},
 		{
 			description:    "should not assign an invalid url, and should return an error",
 			urlParm:        "not a parseable url",
-			expectUrlLogin: "",
+			expectURLLogin: "",
 			isErrNil:       false,
 		},
 	}
@@ -49,7 +49,7 @@ func TestWithLoginURL(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			loginURL = ""
 			err := WithLoginURL(testCase.urlParm)
-			assert.Equal(t, testCase.expectUrlLogin, loginURL)
+			assert.Equal(t, testCase.expectURLLogin, loginURL)
 			assert.Equal(t, testCase.isErrNil, err == nil)
 		})
 	}


### PR DESCRIPTION
This PR builds on the original work from https://github.com/zalando/gin-oauth2/pull/53 and addresses/closes https://github.com/zalando/gin-oauth2/issues/76

* Provides a means to set client id and client secret without a file
* Adds the ability to redirect to login upon failed auth
* Adds tests