### PR TITLE
fix: ci status badge used travis-ci link which we do not use anymore

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -1,0 +1,22 @@
+name: master
+on:
+  push:
+    branches:
+      - master
+permissions: {}
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
+          go-version: '^1.21'
+          check-latest: true
+      - run: go version
+      - run: go vet ./github ./google ./zalando
+      - run: go test ./...
+      - run: go test -race ./...

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Gin-OAuth2
 
 [![Go Report
-Card](https://goreportcard.com/badge/zalando/gin-oauth2)](https://goreportcard.com/report/zalando/gin-oauth2) [![Build Status](https://travis-ci.org/zalando/gin-oauth2.svg?branch=master)](https://travis-ci.org/zalando/gin-oauth2) [![GoDoc](https://godoc.org/github.com/zalando/gin-oauth2?status.svg)](https://godoc.org/github.com/zalando/gin-oauth2)
+Card](https://goreportcard.com/badge/zalando/gin-oauth2)](https://goreportcard.com/report/zalando/gin-oauth2)
+[![Build Status](https://github.com/zalando/gin-oauth2/actions/workflows/master.yaml/badge.svg)](https://github.com/zalando/gin-oauth2/actions/workflows/master.yaml)
+[![GoDoc](https://pkg.go.dev/github.com/zalando/gin-oauth2?status.svg)](https://pkg.go.dev/github.com/zalando/gin-oauth2)
 
 
 Gin-OAuth2 is specially made for [Gin Framework](https://github.com/gin-gonic/gin)


### PR DESCRIPTION
fix: ci status badge used travis-ci link which we do not use anymore