### PR TITLE
Configure .zappr.yaml team

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -7,3 +7,4 @@ approvals:
           - zalando
 # one of [code, doc, config, tools, secrets]
 X-Zalando-Type: code
+X-Zalando-Team: teapot


### PR DESCRIPTION
Configure .zappr.yaml team to get rid of compliance warnings.