### PR TITLE
Group dependabot updates to avoid multiple PRs at a time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-go-mod:
+        patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/" # For GitHub Actions, set the directory to / to check for workflow files in .github/workflows
     schedule:
       interval: "weekly"
+    groups:
+      gh-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Update dependabot config to group updates in a single PR instead of one PR per dependency.

This reduces manual toil when merging updates.